### PR TITLE
changed flex-wrap properties for mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -395,6 +395,10 @@ improved definition and styling of each individual section. */
         /* padding-left: 10px; */
     }
 
+    .work-container {
+        flex-wrap: nowrap;
+    }
+
     /* Hamburger Menu */
     .hamburger {
         display: inline-block;


### PR DESCRIPTION
The flex-wrap property was updated to use nowrap when on smaller screens.  Wrap was causing the screen to overflow it's borders.