### PR TITLE
menu background changed

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -424,11 +424,10 @@ improved definition and styling of each individual section. */
         left: 0;
         bottom: 0;
         z-index: 99;
-        background: black;
+        /* background: black; */
         color: white;
         list-style: none;
         padding-top: 4rem;
-
     }
 
     .showMenu {
@@ -437,6 +436,11 @@ improved definition and styling of each individual section. */
 
     .navigation ul {
         display: inline-block;
+    }
+
+    .navigation ul li {
+        background: black;
+        border-radius: 0%;
     }
 
     


### PR DESCRIPTION
The background color was removed from the full menu and was instead applied only to the list items.  When applied to the full menu it was blocking the contents of the page.  Applying color only to the list items allows for much easier navigation.  The slight curve applied to the border radius of these items on larger displays was also removed on smaller viewports.