### PR TITLE
added listener for menu items

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -7,6 +7,7 @@ const menuIcon = document.querySelector('.menuIcon');
 // jQuery was added for help with debugging display issues.
 menuIconJ = $('.menuIcon');
 menuJ = $('.menu');
+items = $('.menuItem a');
 
 toggleMenu = () => {
     if (menu.classList.contains('showMenu')) {
@@ -21,3 +22,12 @@ toggleMenu = () => {
 }
 
 hamburger.addEventListener('click', toggleMenu);
+
+// This listener was added to improve functionality and close the menu when an option is selected.  This avoids the need for end users to have to manually close the menu after navigating to a new section.
+menu.addEventListener('click', function (e) {
+    console.dir(e.target);
+    if (e.target.tagName === 'A') {
+        toggleMenu();
+    }
+});
+


### PR DESCRIPTION
A new event listener was created and added to the menu.  When a link within the menu is clicked it will run the toggleMenu function to close the menu.  This makes navigating the site easier on mobile devices and removes the needs for users to manually close the menu after navigating to a new section.