### PR TITLE
udpated media queries to reset mobile to column

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -376,6 +376,12 @@ improved definition and styling of each individual section. */
         display: none;
     }
 
+    #apps-2-3, #apps-4-5, #apps-6-7 {
+        flex-direction: column;
+        justify-content: space-evenly;
+        margin-top: 10px;
+    }
+
     #app-1 img {
         width: 100%;
     }


### PR DESCRIPTION
An additional media query statement for mobile devices at 580px as needed after updating tablet settings.  Changes to the tablet flex display properties at 780px  changed the view on mobile devices.  This resets the mobile view.  The application sections needed to be set back to the flex display column property.  Rows are used at 780 to display two images side by side on tablets.